### PR TITLE
Provide user more information about Young's modulus computation

### DIFF
--- a/docs/sec_qg_youngs_modulus.rst
+++ b/docs/sec_qg_youngs_modulus.rst
@@ -75,6 +75,12 @@ shear-thinning :cite:`Herold2017`).
 Click *Apply* for any changes to take effect. The Young's modulus is then
 available for the selected dataset.
 
+.. note::
+
+    In order to prevent users from doing a wrong analysis, Shape-Out does not
+    allow users to change the buffer in the *Dataset* tab if CellCarrier,
+    CellCarrier B or water/PBS were selected in Shape-In. Therefore, the
+    analysis of the Young's modulus cannot be re-done for a different buffer.
 
 
 Bulk actions
@@ -87,7 +93,6 @@ individual datasets. Only valid options are adopted. For instance,
 you will not be able to change the medium for a dataset if a medium is
 already given in its meta data. To verify the options set, you can always
 check the current setting via the *Analysis View* (see above).
-
 
 
 Validity


### PR DESCRIPTION
The calculation of Young's modulus is based on the meta data in the .rtdc file, if CellCarrier, CellCarrier B or water/PBS were selected in Shape-In. This cannot be changed by entering other data in the *Dataset* tab or using the *Bulk action* method. This pull request aims to update Shape-Out and the docs, respectively, to make this more clear.