### PR TITLE
enh: replace findText with findData of comboBox_visc_model

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2.18.2
+ - enh: replace findText with findData of comboBox_visc_model
  - fix: allow to select R binary when not found automatically
  - enh: enable lut selection for emodulus computation in bulk actions (#71)
  - enh: enable lut selection for emodulus computation (#71)

--- a/shapeout2/gui/analysis/ana_slot.py
+++ b/shapeout2/gui/analysis/ana_slot.py
@@ -295,7 +295,7 @@ class SlotPanel(QtWidgets.QWidget):
 
         choices = {"Herold (2017)": "herold-2017",
                    "Buyukurganci (2022)": "buyukurganci-2022"}
-        for name, data in choices:
+        for name, data in choices.items():
             self.comboBox_visc_model.addItem(name, data)
         self.comboBox_visc_model.blockSignals(False)
 

--- a/shapeout2/gui/analysis/ana_slot.py
+++ b/shapeout2/gui/analysis/ana_slot.py
@@ -45,6 +45,7 @@ class SlotPanel(QtWidgets.QWidget):
         self._update_emodulus_medium_choices()
         self._update_emodulus_temp_choices()
         self._update_emodulus_lut_choices()
+        self._update_emodulus_visc_model_choices()
 
         self.update_content()
 
@@ -63,7 +64,7 @@ class SlotPanel(QtWidgets.QWidget):
         else:  # "other", user-defined medium
             emod_visc = self.doubleSpinBox_visc.value()  # user input
             scenario = None
-        emod_visc_model = self.comboBox_visc_model.currentText()
+        emod_visc_model = self.comboBox_visc_model.currentData()
         emod_select_lut = self.comboBox_lut.currentText()
         state = {
             "identifier": slot_state["identifier"],
@@ -139,11 +140,11 @@ class SlotPanel(QtWidgets.QWidget):
             self.comboBox_temp.blockSignals(True)
             self.comboBox_temp.setCurrentIndex(idx_scen)
             self.comboBox_temp.blockSignals(False)
-        idx_vm = self.comboBox_visc_model.findText(
-            emodulus.get("emodulus viscosity model", ""))
-        if idx_vm == -1:
+
+        idx_vm = self.comboBox_visc_model.findData(
             # use defaults from previous session (Herold-2107)
-            idx_vm = 1
+            emodulus.get("emodulus viscosity model", "herold-2017"))
+
         self.comboBox_visc_model.setCurrentIndex(idx_vm)
         # Set current state of the emodulus lut
         idx_lut = self.comboBox_lut.findData(emodulus.get("emodulus lut", ""))
@@ -284,6 +285,20 @@ class SlotPanel(QtWidgets.QWidget):
         self.comboBox_lut.setCurrentIndex(idx)
         self.comboBox_lut.blockSignals(False)
 
+    def _update_emodulus_visc_model_choices(self):
+        """update currently available viscosity model choices for YM
+
+        Signals are blocked.
+        """
+        self.comboBox_visc_model.blockSignals(True)
+        self.comboBox_visc_model.clear()
+
+        choices = {"Herold (2017)": "herold-2017",
+                   "Buyukurganci (2022)": "buyukurganci-2022"}
+        for name, data in choices:
+            self.comboBox_visc_model.addItem(name, data)
+        self.comboBox_visc_model.blockSignals(False)
+
     @property
     def current_slot_state(self):
         if self.slot_ids:
@@ -369,7 +384,7 @@ class SlotPanel(QtWidgets.QWidget):
         medium = self.comboBox_medium.currentData()
         tselec = self.comboBox_temp.currentData()
         medium_key = ALIAS_MEDIA.get(medium, medium)
-        visc_model = self.comboBox_visc_model.currentText()
+        visc_model = self.comboBox_visc_model.currentData()
         # Only show model selection if we are dealing with MC-PBS
         self.comboBox_visc_model.setVisible(medium_key.count("MC-PBS"))
         self.doubleSpinBox_visc.setStyleSheet("")

--- a/tests/test_gui_emodulus.py
+++ b/tests/test_gui_emodulus.py
@@ -285,7 +285,7 @@ def test_changeable_lut_selection(qtbot):
     assert wsl.comboBox_medium.currentData() == "CellCarrier"
 
     # set viscosity model manually
-    idvm = wsl.comboBox_visc_model.findText("buyukurganci-2022")
+    idvm = wsl.comboBox_visc_model.findData("buyukurganci-2022")
     wsl.comboBox_visc_model.setCurrentIndex(idvm)
     # set lut manually
     idlut = wsl.comboBox_lut.findData("HE-2D-FEM-22")
@@ -315,7 +315,7 @@ def test_changeable_lut_selection(qtbot):
     ).config["calculation"]["emodulus lut"] == "HE-3D-FEM-22"
 
     # This is the actual test
-    assert wsl.comboBox_visc_model.currentText() == "buyukurganci-2022"
+    assert wsl.comboBox_visc_model.currentData() == "buyukurganci-2022"
     assert wsl.comboBox_lut.currentText() == "HE-3D-FEM-22"
 
     try:


### PR DESCRIPTION
This PR aims to replace `findText` and `currentText` properties of `comboBox_visc_model` with `findData` and `currentData` for a cleaner programming style. It is mentioned in the issue #167