### PR TITLE
Enable lut selection for isoelasticity lines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2.18.2
+ - enh: enable lut selection to plot isoelasticity lines (#71)
  - fix: allow to select R binary when not found automatically
  - enh: enable lut selection for emodulus computation in bulk actions (#71)
  - enh: enable lut selection for emodulus computation (#71)

--- a/shapeout2/gui/pipeline_plot.py
+++ b/shapeout2/gui/pipeline_plot.py
@@ -486,8 +486,8 @@ def add_isoelastics(plot_item, axis_x, axis_y, channel_width, pixel_size,
     # in Shape-Out 1.
     try:
         iso = isodef.get(
-            lut_identifier=lut_identifier if lut_identifier \
-                else "LE-2D-FEM-19",
+            lut_identifier=lut_identifier if lut_identifier
+            else "LE-2D-FEM-19",
             channel_width=channel_width,
             flow_rate=None,
             viscosity=None,

--- a/shapeout2/gui/pipeline_plot.py
+++ b/shapeout2/gui/pipeline_plot.py
@@ -299,7 +299,8 @@ class PipelinePlotItem(SimplePlotItem):
                                   axis_x=gen["axis x"],
                                   axis_y=gen["axis y"],
                                   channel_width=cfg["setup"]["channel width"],
-                                  pixel_size=cfg["imaging"]["pixel size"])
+                                  pixel_size=cfg["imaging"]["pixel size"],
+                                  lut_identifier=gen.get("lut", None))
             self._plot_elements += els
         # Modifications in log mode
         set_viewbox(self,
@@ -474,7 +475,8 @@ def add_contour(plot_item, plot_state, rtdc_ds, slot_state, legend=None):
     return elements
 
 
-def add_isoelastics(plot_item, axis_x, axis_y, channel_width, pixel_size):
+def add_isoelastics(plot_item, axis_x, axis_y, channel_width, pixel_size,
+                    lut_identifier=None):
     elements = []
     isodef = dclab.isoelastics.get_default()
     # We do not use isodef.get_with_rtdcbase, because then the
@@ -484,7 +486,8 @@ def add_isoelastics(plot_item, axis_x, axis_y, channel_width, pixel_size):
     # in Shape-Out 1.
     try:
         iso = isodef.get(
-            lut_identifier="LE-2D-FEM-19",
+            lut_identifier=lut_identifier if lut_identifier \
+                else "LE-2D-FEM-19",
             channel_width=channel_width,
             flow_rate=None,
             viscosity=None,

--- a/shapeout2/gui/quick_view/qv_main.py
+++ b/shapeout2/gui/quick_view/qv_main.py
@@ -45,7 +45,13 @@ class QuickView(QtWidgets.QWidget):
         self.comboBox_hue.addItem("feature", "feature")
 
         # Set look-up table options for isoelasticity lines
-        self.update_lut_choices()
+        self.comboBox_lut.clear()
+        lut_dict = dclab.features.emodulus.load.get_internal_lut_names_dict()
+        for lut_id in lut_dict.keys():
+            self.comboBox_lut.addItem(lut_id, lut_id)
+        # Set LE-2D-FEM-19 as a default
+        idx = self.comboBox_lut.findData("LE-2D-FEM-19")
+        self.comboBox_lut.setCurrentIndex(idx)
 
         # settings button
         self.toolButton_event.toggled.connect(self.on_tool)
@@ -806,18 +812,6 @@ class QuickView(QtWidgets.QWidget):
             self.comboBox_x.update_feature_list(default_choice="area_um")
             self.comboBox_y.update_feature_list(default_choice="deform")
             self.comboBox_z_hue.update_feature_list()
-
-    def update_lut_choices(self):
-        """Updates the look-up table comboboxes choices"""
-        self.comboBox_lut.blockSignals(True)
-        self.comboBox_lut.clear()
-        lut_dict = dclab.features.emodulus.load.get_internal_lut_names_dict()
-        for lut_id in lut_dict.keys():
-            self.comboBox_lut.addItem(lut_id, lut_id)
-        # Set LE-2D-FEM-19 as a default
-        idx = self.comboBox_lut.findData("LE-2D-FEM-19")
-        self.comboBox_lut.setCurrentIndex(idx)
-        self.comboBox_lut.blockSignals(False)
 
     def update_polygon_panel(self):
         """Update polygon filter combobox etc."""

--- a/shapeout2/gui/quick_view/qv_main.py
+++ b/shapeout2/gui/quick_view/qv_main.py
@@ -44,6 +44,9 @@ class QuickView(QtWidgets.QWidget):
         self.comboBox_hue.addItem("KDE", "kde")
         self.comboBox_hue.addItem("feature", "feature")
 
+        # Set look-up table options for isoelasticity lines
+        self.update_lut_choices()
+
         # settings button
         self.toolButton_event.toggled.connect(self.on_tool)
         self.toolButton_poly.toggled.connect(self.on_tool)
@@ -98,6 +101,7 @@ class QuickView(QtWidgets.QWidget):
                                self.comboBox_z_hue,
                                self.comboBox_hue,
                                self.checkBox_hue,
+                               self.comboBox_lut
                                ]
         for w in self.signal_widgets:
             if hasattr(w, "currentIndexChanged"):
@@ -151,6 +155,7 @@ class QuickView(QtWidgets.QWidget):
             "scale x": self.comboBox_xscale.currentData(),
             "scale y": self.comboBox_yscale.currentData(),
             "isoelastics": self.checkBox_isoelastics.isChecked(),
+            "lut": self.comboBox_lut.currentData(),
             "marker hue": self.checkBox_hue.isChecked(),
             "marker hue value": self.comboBox_hue.currentData(),
             "marker hue feature": self.comboBox_z_hue.currentData(),
@@ -188,6 +193,8 @@ class QuickView(QtWidgets.QWidget):
             # scaling
             ("scale x", self.comboBox_xscale),
             ("scale y", self.comboBox_yscale),
+            # look up table
+            ("lut", self.comboBox_lut),
             # marker hue
             ("marker hue value", self.comboBox_hue),
             ("marker hue feature", self.comboBox_z_hue),
@@ -584,7 +591,8 @@ class QuickView(QtWidgets.QWidget):
                                           yscale=plot["scale y"],
                                           hue_type=hue_type,
                                           hue_kwargs=hue_kwargs,
-                                          isoelastics=plot["isoelastics"])
+                                          isoelastics=plot["isoelastics"],
+                                          lut_identifier=plot["lut"])
             # make sure the correct plot items are visible
             # (e.g. scatter select)
             self.on_tool()
@@ -798,6 +806,18 @@ class QuickView(QtWidgets.QWidget):
             self.comboBox_x.update_feature_list(default_choice="area_um")
             self.comboBox_y.update_feature_list(default_choice="deform")
             self.comboBox_z_hue.update_feature_list()
+
+    def update_lut_choices(self):
+        """Updates the look-up table comboboxes choices"""
+        self.comboBox_lut.blockSignals(True)
+        self.comboBox_lut.clear()
+        lut_dict = dclab.features.emodulus.load.get_internal_lut_names_dict()
+        for lut_id in lut_dict.keys():
+            self.comboBox_lut.addItem(lut_id, lut_id)
+        # Set LE-2D-FEM-19 as a default
+        idx = self.comboBox_lut.findData("LE-2D-FEM-19")
+        self.comboBox_lut.setCurrentIndex(idx)
+        self.comboBox_lut.blockSignals(False)
 
     def update_polygon_panel(self):
         """Update polygon filter combobox etc."""

--- a/shapeout2/gui/quick_view/qv_main.ui
+++ b/shapeout2/gui/quick_view/qv_main.ui
@@ -367,14 +367,40 @@
          </layout>
         </item>
         <item>
-         <widget class="QCheckBox" name="checkBox_isoelastics">
-          <property name="text">
-           <string>Show isoelasticity lines</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <widget class="QCheckBox" name="checkBox_isoelastics">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Show isoelasticity lines</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBox_lut"/>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_10">
@@ -1101,22 +1127,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>checkBox_auto_apply</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>toolButton_apply</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>882</x>
-     <y>244</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>966</x>
-     <y>244</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>comboBox_hue</sender>
    <signal>currentIndexChanged(int)</signal>

--- a/shapeout2/gui/quick_view/qv_scatter.py
+++ b/shapeout2/gui/quick_view/qv_scatter.py
@@ -89,8 +89,8 @@ class QuickViewScatterWidget(SimplePlotWidget):
 
     def plot_data(self, rtdc_ds, slot, xax="area_um", yax="deform",
                   xscale="linear", yscale="linear",  downsample=False,
-                  hue_type="none", hue_kwargs=None,
-                  isoelastics=False):
+                  hue_type="none", hue_kwargs=None, isoelastics=False,
+                  lut_identifier=None):
         self.rtdc_ds = rtdc_ds
         self.slot = slot
         self.xax = xax
@@ -170,7 +170,8 @@ class QuickViewScatterWidget(SimplePlotWidget):
                 axis_x=self.xax,
                 axis_y=self.yax,
                 channel_width=cfg["setup"]["channel width"],
-                pixel_size=cfg["imaging"]["pixel size"])
+                pixel_size=cfg["imaging"]["pixel size"],
+                lut_identifier=lut_identifier)
 
     def set_mouse_click_mode(self, mode):
         allowed = ["scatter", "poly-create", "poly-modify"]

--- a/tests/test_gui_quickview.py
+++ b/tests/test_gui_quickview.py
@@ -9,7 +9,6 @@ from shapeout2.gui.main import ShapeOut2
 from shapeout2 import session
 import pytest
 
-
 datapath = pathlib.Path(__file__).parent / "data"
 
 
@@ -417,3 +416,49 @@ def test_subtract_background(qtbot):
             " Subtract Background-Checkbox is visible for dataset "
             " that don't contain \"image_bg\"-feature"
             )
+
+
+def test_isoelasticity_lines_with_lut_selection(qtbot):
+    """Test look-up table selection for isoelasticity lines"""
+
+    mw = ShapeOut2()
+    qtbot.addWidget(mw)
+
+    # add a dataslot
+    path = datapath / "calibration_beads_47.rtdc"
+    filt_id = mw.add_filter()
+    slot_ids = mw.add_dataslot(paths=[path])
+
+    assert len(mw.pipeline.slot_ids) == 1, "we added that"
+    assert len(mw.pipeline.filter_ids) == 1, "automatically added"
+
+    # activate a dataslot
+    slot_id = slot_ids[0]
+    em = mw.block_matrix.get_widget(slot_id, filt_id)
+    qtbot.mouseClick(em, QtCore.Qt.LeftButton, QtCore.Qt.ShiftModifier)
+
+    em = mw.block_matrix.get_widget(slot_id, filt_id)
+    qtbot.mouseClick(em, QtCore.Qt.LeftButton)
+
+    # did that work?
+    assert mw.toolButton_quick_view.isChecked()
+
+    # Get QuickView instance
+    qv = mw.widget_quick_view
+
+    # Open plot (settings) tool of QuickView
+    plot_tool = qv.toolButton_settings
+    qtbot.mouseClick(plot_tool, QtCore.Qt.LeftButton)
+
+    # Test if checkbox is visible and checked by default
+    assert qv.checkBox_isoelastics.isChecked(), "Checked by default"
+    # Test if default look-up table is selected
+    assert qv.comboBox_lut.currentData() == "LE-2D-FEM-19", "Check default LUT"
+
+    # Try changing look-up table
+    qv.comboBox_lut.setCurrentIndex(qv.comboBox_lut.findData("HE-2D-FEM-22"))
+    # Apply changes by clicking on 'Apply'
+    qtbot.mouseClick(qv.toolButton_apply, QtCore.Qt.LeftButton)
+
+    # did that work?
+    assert qv.comboBox_lut.currentData() == "HE-2D-FEM-22"


### PR DESCRIPTION
This PR aims to implement the selection of LUT in the quick view to plot different isoelasticity lines. This is mentioned as a fourth point in the issue #71 .