### PR TITLE
Enable selection of lut identifier for plots in analysis view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2.19.0
+ - enh: enable lut selection in analysis view plots (#71)
  - fix: only allow user to choose "R.exe" in R binary manual search (#173)
  - enh: correctly show system R binary in settings
  - ref: migrate from pyqt5 to pyqt6 (#165)

--- a/shapeout2/gui/analysis/ana_plot.py
+++ b/shapeout2/gui/analysis/ana_plot.py
@@ -94,6 +94,7 @@ class PlotPanel(QtWidgets.QWidget):
                 "axis x": self.comboBox_axis_x.currentData(),
                 "axis y": self.comboBox_axis_y.currentData(),
                 "isoelastics": self.checkBox_isoelastics.isChecked(),
+                "lut": self.comboBox_lut.currentData(),
                 "kde": self.comboBox_kde.currentData(),
                 "range x": [rx["start"], rx["end"]],
                 "range y": [ry["start"], ry["end"]],
@@ -161,6 +162,8 @@ class PlotPanel(QtWidgets.QWidget):
         self.comboBox_axis_y.setCurrentIndex(
             self.comboBox_axis_y.findData(gen["axis y"]))
         self.checkBox_isoelastics.setChecked(gen["isoelastics"])
+        lut_index = self.comboBox_lut.findData(gen.get("lut", "LE-2D-FEM-19"))
+        self.comboBox_lut.setCurrentIndex(lut_index)
         kde_index = self.comboBox_kde.findData(gen["kde"])
         self.comboBox_kde.setCurrentIndex(kde_index)
         scx_index = self.comboBox_scale_x.findData(gen["scale x"])
@@ -211,6 +214,11 @@ class PlotPanel(QtWidgets.QWidget):
 
     def _init_controls(self):
         """All controls that are not subject to change"""
+        # LUT
+        self.comboBox_lut.clear()
+        lut_dict = dclab.features.emodulus.load.get_internal_lut_names_dict()
+        for lut_id in lut_dict.keys():
+            self.comboBox_lut.addItem(lut_id, lut_id)
         # KDE
         kde_names = STATE_OPTIONS["general"]["kde"]
         self.comboBox_kde.clear()

--- a/shapeout2/gui/analysis/ana_plot.ui
+++ b/shapeout2/gui/analysis/ana_plot.ui
@@ -426,6 +426,26 @@
            </widget>
           </item>
           <item>
+           <widget class="QComboBox" name="comboBox_lut"/>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_19">
+          <item>
            <widget class="QCheckBox" name="checkBox_auto_range">
             <property name="text">
              <string>Auto XY-range</string>
@@ -436,13 +456,13 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_5">
+           <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>0</width>
+              <width>40</width>
               <height>20</height>
              </size>
             </property>

--- a/tests/test_gui_plotting.py
+++ b/tests/test_gui_plotting.py
@@ -272,3 +272,36 @@ def test_remove_plots_issue_36(qtbot):
     # remove a plot
     pw = mw.block_matrix.get_widget(filt_plot_id=plot_id)
     pw.action_remove()
+
+
+def test_changing_lut_identifier_in_analysis_view_plots(qtbot):
+    """Test LUT identifier user interaction in analysis view plots."""
+    mw = ShapeOut2()
+    qtbot.addWidget(mw)
+
+    # add a dataslot
+    path = datapath / "calibration_beads_47.rtdc"
+    mw.add_dataslot(paths=[path])
+
+    # add a plot
+    plot_id = mw.add_plot()
+
+    # activate analysis view
+    pe = mw.block_matrix.get_widget(filt_plot_id=plot_id)
+    qtbot.mouseClick(pe.toolButton_modify, QtCore.Qt.MouseButton.LeftButton)
+
+    pv = mw.widget_ana_view.widget_plot
+
+    # Change to "HE-2D-FEM-22" and apply
+    idx = pv.comboBox_lut.findData("HE-2D-FEM-22")
+    pv.comboBox_lut.setCurrentIndex(idx)
+    qtbot.mouseClick(pv.pushButton_apply, QtCore.Qt.MouseButton.LeftButton)
+
+    assert pv.comboBox_lut.currentData() == "HE-2D-FEM-22"
+
+    # Change to "HE-3D-FEM-22" and apply
+    idx = pv.comboBox_lut.findData("HE-3D-FEM-22")
+    pv.comboBox_lut.setCurrentIndex(idx)
+    qtbot.mouseClick(pv.pushButton_apply, QtCore.Qt.MouseButton.LeftButton)
+
+    assert pv.comboBox_lut.currentData() == "HE-3D-FEM-22"


### PR DESCRIPTION
<!-- brief intro. What does this merge request aim to do and why -->
## Intro
This PR aims to enable the selection of LUT identifiers for plots in the analysis view.
This is a new requested feature. It is explained in the issue #71.

<!-- Step by step guide, this helps! -->
### To do:
- [x] change the code (UI file & logic) to enable lut selection
- [x] CI/CD pipeline passed
- [x] Tests pass locally (run `pytest tests` on your computer)
- [x] update CHANGELOG
