### PR TITLE
Persist feature selection in QuickView when switching data slots

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2.21.6
+ - fix: persist feature selection in QuickView when switching data slots (#206)
 2.21.5
  - fix: disable table graphs widget when an image-type table is shown
  - fix: accessing table data from DCOR

--- a/shapeout2/gui/widgets/feature_combobox.py
+++ b/shapeout2/gui/widgets/feature_combobox.py
@@ -1,7 +1,6 @@
 import dclab
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-
 #: These are features only visible in developer mode
 HIDDEN_FEATURES = []
 for ii in range(10):
@@ -121,7 +120,7 @@ class FeatureComboBox(QtWidgets.QComboBox):
         if feat_cur and feat_cur in ds_feats:
             # If the previous selection exists in the new feature list, set it.
             idx_cur = self.findData(feat_cur)
-        elif feat_cur not in ds_feats and idx_cur >= 0:
+        else:
             # If the previous selection does not exist in the new feature list,
             # select the first available feature in `default_choices`
             idx_cur = -1

--- a/shapeout2/gui/widgets/feature_combobox.py
+++ b/shapeout2/gui/widgets/feature_combobox.py
@@ -118,17 +118,18 @@ class FeatureComboBox(QtWidgets.QComboBox):
             item.setToolTip(tip)
             model.appendRow(item)
 
-        if idx_cur < 0:  # no selection made by user
-            # Use the first available feature in `default_choices`
+        # If the previous selection exists in the new feature list, set it.
+        if not feat_cur and feat_cur in ds_feats:
+            idx_cur = self.findData(feat_cur)
+
+        # If no selection made by user, select the first available feature
+        # in `default_choices`
+        elif idx_cur < 0:
             for choice in self.default_choices:
                 idx_choice = self.findData(choice)
                 if idx_choice >= 0:
                     idx_cur = idx_choice
                     break
-        # If selection made by user and the selection exists in the new
-        # feature list, set it
-        if feat_cur in ds_feats:
-            idx_cur = self.findData(feat_cur)
 
         self.setCurrentIndex(idx_cur)
 

--- a/shapeout2/gui/widgets/feature_combobox.py
+++ b/shapeout2/gui/widgets/feature_combobox.py
@@ -100,6 +100,10 @@ class FeatureComboBox(QtWidgets.QComboBox):
         # based on self.default_choices in the end.
         idx_cur = self.currentIndex()
 
+        # Remember user selection. If it exists in ds_feats, the selection
+        # will persist even if the user switches the dataset.
+        feat_cur = self.currentData(self.data_role)
+
         blocked = self.signalsBlocked()  # remember block state
         self.blockSignals(True)
 
@@ -121,6 +125,11 @@ class FeatureComboBox(QtWidgets.QComboBox):
                 if idx_choice >= 0:
                     idx_cur = idx_choice
                     break
+        # If selection made by user and the selection exists in the new
+        # feature list, set it
+        if feat_cur in ds_feats:
+            idx_cur = self.findData(feat_cur)
+
         self.setCurrentIndex(idx_cur)
 
         # set previous selection

--- a/shapeout2/gui/widgets/feature_combobox.py
+++ b/shapeout2/gui/widgets/feature_combobox.py
@@ -118,13 +118,17 @@ class FeatureComboBox(QtWidgets.QComboBox):
             item.setToolTip(tip)
             model.appendRow(item)
 
-        # If the previous selection exists in the new feature list, set it.
         if feat_cur and feat_cur in ds_feats:
+            # If the previous selection exists in the new feature list, set it.
             idx_cur = self.findData(feat_cur)
+        elif feat_cur not in ds_feats and idx_cur >= 0:
+            # If the previous selection does not exist in the new feature list,
+            # select the first available feature in `default_choices`
+            idx_cur = -1
 
-        # If no selection made by user, select the first available feature
-        # in `default_choices`
-        elif idx_cur < 0:
+        if idx_cur < 0:
+            # If no selection made by user, select the first available feature
+            # in `default_choices`
             for choice in self.default_choices:
                 idx_choice = self.findData(choice)
                 if idx_choice >= 0:

--- a/shapeout2/gui/widgets/feature_combobox.py
+++ b/shapeout2/gui/widgets/feature_combobox.py
@@ -119,7 +119,7 @@ class FeatureComboBox(QtWidgets.QComboBox):
             model.appendRow(item)
 
         # If the previous selection exists in the new feature list, set it.
-        if not feat_cur and feat_cur in ds_feats:
+        if feat_cur and feat_cur in ds_feats:
             idx_cur = self.findData(feat_cur)
 
         # If no selection made by user, select the first available feature

--- a/tests/test_gui_quickview.py
+++ b/tests/test_gui_quickview.py
@@ -2,14 +2,14 @@
 import pathlib
 import shutil
 
+import dclab
 import h5py
+import numpy as np
+import pytest
 from PyQt6 import QtCore, QtWidgets
 
-import dclab
-import numpy as np
-from shapeout2.gui.main import ShapeOut2
 from shapeout2 import session
-import pytest
+from shapeout2.gui.main import ShapeOut2
 
 datapath = pathlib.Path(__file__).parent / "data"
 
@@ -903,8 +903,10 @@ def test_isoelasticity_lines_with_lut_selection(qtbot):
 
 
 def test_select_x_y_axis_based_on_availiable_feature_name_issue_206(qtbot):
-    """Test select X- axis and Y- axis based on feature name that is
-    available in both datasets."""
+    """
+    Test select X-axis and Y-axis based on feature name that is available
+    in both datasets.
+    """
 
     mw = ShapeOut2()
     qtbot.addWidget(mw)
@@ -963,8 +965,10 @@ def test_select_x_y_axis_based_on_availiable_feature_name_issue_206(qtbot):
 
 
 def test_select_x_y_axis_based_on_unavailable_feature_name_issue_206(qtbot):
-    """Test select X- axis and Y- axis based on feature name that is not
-    available in both datasets."""
+    """
+    Test select X-axis and Y-axis based on feature name that is not available
+    in both datasets.
+    """
 
     mw = ShapeOut2()
     qtbot.addWidget(mw)

--- a/tests/test_gui_quickview.py
+++ b/tests/test_gui_quickview.py
@@ -902,9 +902,9 @@ def test_isoelasticity_lines_with_lut_selection(qtbot):
     assert qv.comboBox_lut.currentData() == "HE-2D-FEM-22"
 
 
-def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
-    """Test select X- axis and Y- axis based on feature name, not on list
-    index"""
+def test_select_x_y_axis_based_on_availiable_feature_name_issue_206(qtbot):
+    """Test select X- axis and Y- axis based on feature name that is
+    available in both datasets."""
 
     mw = ShapeOut2()
     qtbot.addWidget(mw)
@@ -922,12 +922,12 @@ def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
     filt_id = mw.pipeline.filter_ids[0]
 
     # activate dataslot-1
-    em = mw.block_matrix.get_widget(slot_id1, filt_id)
-    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton,
+    em1 = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em1, QtCore.Qt.MouseButton.LeftButton,
                      QtCore.Qt.KeyboardModifier.ShiftModifier)
 
-    em = mw.block_matrix.get_widget(slot_id1, filt_id)
-    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton)
+    em1 = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em1, QtCore.Qt.MouseButton.LeftButton)
 
     # did that work?
     assert mw.toolButton_quick_view.isChecked()
@@ -950,9 +950,76 @@ def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
     # Get the slot_id the second data slot
     slot_id2 = mw.pipeline.slot_ids[1]
     # Activate data slot-2
-    em = mw.block_matrix.get_widget(slot_id2, filt_id)
-    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton)
+    em2 = mw.block_matrix.get_widget(slot_id2, filt_id)
+    qtbot.mouseClick(em2, QtCore.Qt.MouseButton.LeftButton,
+                     QtCore.Qt.KeyboardModifier.ShiftModifier)
+
+    em2 = mw.block_matrix.get_widget(slot_id2, filt_id)
+    qtbot.mouseClick(em2, QtCore.Qt.MouseButton.LeftButton)
 
     # Check if X-axis and Y-axis features are still set correctly
     assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
     assert qv.comboBox_y.currentData() == "frame", "Check manual selection"
+
+
+def test_select_x_y_axis_based_on_unavailable_feature_name_issue_206(qtbot):
+    """Test select X- axis and Y- axis based on feature name that is not
+    available in both datasets."""
+
+    mw = ShapeOut2()
+    qtbot.addWidget(mw)
+
+    # add dataslots
+    path1 = datapath / "calibration_beads_47.rtdc"
+    path2 = datapath / "blood_rbc_leukocytes.rtdc"
+    mw.add_dataslot(paths=[path1, path2])
+
+    assert len(mw.pipeline.slot_ids) == 2, "we added that"
+    assert len(mw.pipeline.filter_ids) == 1, "automatically added"
+
+    # Get the slot_id of the first data slot
+    slot_id1 = mw.pipeline.slot_ids[0]
+    filt_id = mw.pipeline.filter_ids[0]
+
+    # activate dataslot-1
+    em1 = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em1, QtCore.Qt.MouseButton.LeftButton,
+                     QtCore.Qt.KeyboardModifier.ShiftModifier)
+
+    em1 = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em1, QtCore.Qt.MouseButton.LeftButton)
+
+    # did that work?
+    assert mw.toolButton_quick_view.isChecked()
+
+    # Get QuickView instance
+    qv = mw.widget_quick_view
+
+    # Open plot (settings) tool of QuickView
+    plot_tool = qv.toolButton_settings
+    qtbot.mouseClick(plot_tool, QtCore.Qt.MouseButton.LeftButton)
+
+    # Set X-axis and Y-axis features in data slot 1
+    qv.comboBox_x.setCurrentIndex(qv.comboBox_x.findData("area_um"))
+    # Set the feature that is not available in dataset-2
+    qv.comboBox_y.setCurrentIndex(qv.comboBox_y.findData("fl3_width"))
+
+    # Check if X-axis and Y-axis features are set correctly
+    assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
+    assert qv.comboBox_y.currentData() == "fl3_width", "Check manual selection"
+
+    # Get the slot_id the second data slot
+    slot_id2 = mw.pipeline.slot_ids[1]
+    # Activate data slot-2
+    em2 = mw.block_matrix.get_widget(slot_id2, filt_id)
+    qtbot.mouseClick(em2, QtCore.Qt.MouseButton.LeftButton,
+                     QtCore.Qt.KeyboardModifier.ShiftModifier)
+
+    em2 = mw.block_matrix.get_widget(slot_id2, filt_id)
+    qtbot.mouseClick(em2, QtCore.Qt.MouseButton.LeftButton)
+
+    # Check if X-axis and Y-axis features are still set correctly
+    assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
+    # Since the feature is not available in dataset-2, it should be set
+    # to "deform" (first option in default choice)
+    assert qv.comboBox_y.currentData() == "deform", "Check manual selection"

--- a/tests/test_gui_quickview.py
+++ b/tests/test_gui_quickview.py
@@ -900,3 +900,59 @@ def test_isoelasticity_lines_with_lut_selection(qtbot):
 
     # did that work?
     assert qv.comboBox_lut.currentData() == "HE-2D-FEM-22"
+
+
+def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
+    """Test select X- axis and Y- axis based on feature name, not on list
+    index"""
+
+    mw = ShapeOut2()
+    qtbot.addWidget(mw)
+
+    # add dataslots
+    path1 = datapath / "calibration_beads_47.rtdc"
+    path2 = datapath / "blood_rbc_leukocytes.rtdc"
+    mw.add_dataslot(paths=[path1, path2])
+
+    assert len(mw.pipeline.slot_ids) == 2, "we added that"
+    assert len(mw.pipeline.filter_ids) == 1, "automatically added"
+
+    # Get the slot_id of the first data slot
+    slot_id1 = mw.pipeline.slot_ids[0]
+    filt_id = mw.pipeline.filter_ids[0]
+
+    # activate dataslot-1
+    em = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton,
+                     QtCore.Qt.KeyboardModifier.ShiftModifier)
+
+    em = mw.block_matrix.get_widget(slot_id1, filt_id)
+    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton)
+
+    # did that work?
+    assert mw.toolButton_quick_view.isChecked()
+
+    # Get QuickView instance
+    qv = mw.widget_quick_view
+
+    # Open plot (settings) tool of QuickView
+    plot_tool = qv.toolButton_settings
+    qtbot.mouseClick(plot_tool, QtCore.Qt.MouseButton.LeftButton)
+
+    # Set X-axis and Y-axis features in data slot 1
+    qv.comboBox_x.setCurrentIndex(qv.comboBox_x.findData("area_um"))
+    qv.comboBox_y.setCurrentIndex(qv.comboBox_y.findData("deform"))
+
+    # Check if X-axis and Y-axis features are set correctly
+    assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
+    assert qv.comboBox_y.currentData() == "deform", "Check manual selection"
+
+    # Get the slot_id the second data slot
+    slot_id2 = mw.pipeline.slot_ids[1]
+    # Activate data slot-2
+    em = mw.block_matrix.get_widget(slot_id2, filt_id)
+    qtbot.mouseClick(em, QtCore.Qt.MouseButton.LeftButton)
+
+    # Check if X-axis and Y-axis features are still set correctly
+    assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
+    assert qv.comboBox_y.currentData() == "deform", "Check manual selection"

--- a/tests/test_gui_quickview.py
+++ b/tests/test_gui_quickview.py
@@ -941,11 +941,11 @@ def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
 
     # Set X-axis and Y-axis features in data slot 1
     qv.comboBox_x.setCurrentIndex(qv.comboBox_x.findData("area_um"))
-    qv.comboBox_y.setCurrentIndex(qv.comboBox_y.findData("deform"))
+    qv.comboBox_y.setCurrentIndex(qv.comboBox_y.findData("frame"))
 
     # Check if X-axis and Y-axis features are set correctly
     assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
-    assert qv.comboBox_y.currentData() == "deform", "Check manual selection"
+    assert qv.comboBox_y.currentData() == "frame", "Check manual selection"
 
     # Get the slot_id the second data slot
     slot_id2 = mw.pipeline.slot_ids[1]
@@ -955,4 +955,4 @@ def test_select_x_y_axis_based_on_feature_name_issue_206(qtbot):
 
     # Check if X-axis and Y-axis features are still set correctly
     assert qv.comboBox_x.currentData() == "area_um", "Check manual selection"
-    assert qv.comboBox_y.currentData() == "deform", "Check manual selection"
+    assert qv.comboBox_y.currentData() == "frame", "Check manual selection"


### PR DESCRIPTION
This PR aims to address the bug described in the issue #206, which caused selected features in the Quickview to be lost when users switched between data slots.

### TODO:
- [x] Modified the logic to persist user selection when switching the data slots in quickview in the file `shapeout2\gui\widgets\feature_combobox.py`
- [x] Create test function and test it locally
- [x] CICD passed
- [x] Update CHANGELOG
